### PR TITLE
Fix performance for gatheInfo func, move regexp to global var for onc…

### DIFF
--- a/envconfig.go
+++ b/envconfig.go
@@ -18,6 +18,8 @@ import (
 // ErrInvalidSpecification indicates that a specification is of the wrong type.
 var ErrInvalidSpecification = errors.New("specification must be a struct pointer")
 
+var gatherRegexp = regexp.MustCompile("([^A-Z]+|[A-Z][^A-Z]+|[A-Z]+)")
+
 // A ParseError occurs when an environment variable cannot be converted to
 // the type required by a struct field during assignment.
 type ParseError struct {
@@ -55,7 +57,6 @@ type varInfo struct {
 
 // GatherInfo gathers information about the specified struct
 func gatherInfo(prefix string, spec interface{}) ([]varInfo, error) {
-	expr := regexp.MustCompile("([^A-Z]+|[A-Z][^A-Z]+|[A-Z]+)")
 	s := reflect.ValueOf(spec)
 
 	if s.Kind() != reflect.Ptr {
@@ -101,7 +102,7 @@ func gatherInfo(prefix string, spec interface{}) ([]varInfo, error) {
 
 		// Best effort to un-pick camel casing as separate words
 		if isTrue(ftype.Tag.Get("split_words")) {
-			words := expr.FindAllStringSubmatch(ftype.Name, -1)
+			words := gatherRegexp.FindAllStringSubmatch(ftype.Name, -1)
 			if len(words) > 0 {
 				var name []string
 				for _, words := range words {
@@ -170,7 +171,7 @@ func Process(prefix string, spec interface{}) error {
 			continue
 		}
 
-		err := processField(value, info.Field)
+		err = processField(value, info.Field)
 		if err != nil {
 			return &ParseError{
 				KeyName:   info.Key,

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -715,3 +715,28 @@ func (ss *setterStruct) Set(value string) error {
 	ss.Inner = fmt.Sprintf("setterstruct{%q}", value)
 	return nil
 }
+
+func BenchmarkGatherInfo(b *testing.B) {
+	os.Clearenv()
+	os.Setenv("ENV_CONFIG_DEBUG", "true")
+	os.Setenv("ENV_CONFIG_PORT", "8080")
+	os.Setenv("ENV_CONFIG_RATE", "0.5")
+	os.Setenv("ENV_CONFIG_USER", "Kelsey")
+	os.Setenv("ENV_CONFIG_TIMEOUT", "2m")
+	os.Setenv("ENV_CONFIG_ADMINUSERS", "John,Adam,Will")
+	os.Setenv("ENV_CONFIG_MAGICNUMBERS", "5,10,20")
+	os.Setenv("ENV_CONFIG_COLORCODES", "red:1,green:2,blue:3")
+	os.Setenv("SERVICE_HOST", "127.0.0.1")
+	os.Setenv("ENV_CONFIG_TTL", "30")
+	os.Setenv("ENV_CONFIG_REQUIREDVAR", "foo")
+	os.Setenv("ENV_CONFIG_IGNORED", "was-not-ignored")
+	os.Setenv("ENV_CONFIG_OUTER_INNER", "iamnested")
+	os.Setenv("ENV_CONFIG_AFTERNESTED", "after")
+	os.Setenv("ENV_CONFIG_HONOR", "honor")
+	os.Setenv("ENV_CONFIG_DATETIME", "2016-08-16T18:57:05Z")
+	os.Setenv("ENV_CONFIG_MULTI_WORD_VAR_WITH_AUTO_SPLIT", "24")
+	for i := 0; i < b.N; i++ {
+		var s Specification
+		gatherInfo("env_config", &s)
+	}
+}


### PR DESCRIPTION
…e regexp compilation.

Benchmark result:

goos: linux
goarch: amd64
pkg: github.com/kelseyhightower/envconfig

benchmark                 old ns/op     new ns/op     delta
BenchmarkGatherInfo-4     756307        535401        -29.21%

benchmark                 old allocs     new allocs     delta
BenchmarkGatherInfo-4     349            251            -28.08%

benchmark                 old bytes     new bytes     delta
BenchmarkGatherInfo-4     64467         15425         -76.07%